### PR TITLE
Migrate bundler based project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/.bundle/
+Gemfile.lock
+/vendor/

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gemspec

--- a/windows-api.gemspec
+++ b/windows-api.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency('win32-api', '>= 1.4.5')
   spec.add_development_dependency('test-unit')
+  spec.add_development_dependency('windows-pr','~>1.2.4')
 
   spec.description = <<-EOF
     The windows-api library provides features over and above the basic


### PR DESCRIPTION
Before adding CI service(s), we should tidy up gem dependency with bundler to simplify preparing CI tasks.
After Applying these patches, we can execute tests the following commands:

```log
$ bundle install
$ bundle exec rake test
```