### PR TITLE
Support Appveyor CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,21 @@
+version: '{build}'
+
+install:
+  - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%
+  - ruby --version
+  - gem --version
+  - bundle install
+build: off
+test_script:
+  - bundle exec rake test
+
+environment:
+  matrix:
+    - ruby_version: "23-x64"
+    - ruby_version: "23"
+    - ruby_version: "22-x64"
+    - ruby_version: "22"
+    - ruby_version: "21-x64"
+    - ruby_version: "21"
+    - ruby_version: "200-x64"
+    - ruby_version: "200"

--- a/windows-api.gemspec
+++ b/windows-api.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency('win32-api', '>= 1.4.5')
   spec.add_development_dependency('test-unit')
+  spec.add_development_dependency('rake')
   spec.add_development_dependency('windows-pr','~>1.2.4')
 
   spec.description = <<-EOF


### PR DESCRIPTION
CI target Ruby version is 2.0.0 or later.
Because win32-api 1.6.0 does not contain 1.8.7 and 1.9.3 binaries.